### PR TITLE
add CHANNEL_STREAM to enable setting pre-ga releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ oc --context app.ci -n konflux-tp extract secret/gangway-token-dockercfg-wbq9f
     - Reference the pipeline you created.
     - Set the context to the specific component you want to test (remove the default application context).
 
+
+## Pipeline Flow
+The pipeline consists of the following tasks:
+- **run-prowjob**: This task triggers a prowjob based on the parameters you provide.
+- **report-prowjob-status**: This task waits for the prowjob to complete, checks its status and reports the result.
+
+## Parameters
+| name | description | default value | required |
+|------|-------------|----------------|----------|
+| SNAPSHOT | Snapshot of the application |  | true |
+| GANGWAY_TOKEN | Token to authenticate with gangway | gangway-token | false |
+| CLOUD_PROVIDER | Cloud provider to use for the test (one of aws, gcp, azure) | aws | false |
+| OPENSHIFT_VERSION | OpenShift version to test against; must be in the format 4.x; if you are using a stable, fast or candidate channel, you can specify 4.x.y | 4.18 | false |
+| CHANNEL_STREAM | OpenShift stream/channel to test against; one of stable, fast, candidate, 4-stable, nightly, konflux-nightly, ci; stable, fast and candidate are channels from the Cincinnati server, the other ones are streams from the release controller; always the latest version of the stream/channel will be used | stable | false |
+| ARCHITECTURE | Architecture to test against; one of amd64, arm64 | amd64 | false |
+| ARTIFACTS_BUILD_ROOT | Image to use for building the artifacts image, e.g. quay-proxy.ci.openshift.org/openshift/ci:ocp_builder_rhel-9-golang-1.22-openshift-4.17 |  | true |
+| DOCKERFILE_ADDITIONS | Dockerfile additions to use for building the artifacts image, e.g. RUN make build |  | true |
+| DEPLOY_TEST_COMMAND | Command that deploys and tests the OPERATOR_IMAGE on the cluster, e.g. make deploy && make test |  | true |
+| BUNDLE_PRE_TEST_COMMAND | Only use with bundle image test! Pre-test command to run before the test, e.g. oc apply ... |  | false |
+| BUNDLE_NS | Namespace to use if installing bundle image |  | false |
+| PULL_SECRET | Secret created by the user in https://vault.ci.openshift.org/ in the test-credential namespace with the field .dockerconfigjson; necessary for private images |  | false |
+| ENVS | Optional environment variables to inject into the test; separated by commas; e.g. VAR1=val1,VAR2=val2 |  | false |
+
+
+
 ## ⚙️ How It Works
 The pipeline will trigger one of these prowjobs, depending on the specified parameters:
   - `periodic-ci-openshift-konflux-tasks-main-konflux-test-aws`

--- a/examples/pipeline-bundle.yaml
+++ b/examples/pipeline-bundle.yaml
@@ -31,6 +31,8 @@ spec:
       value: "gcp"
     - name: OPENSHIFT_VERSION
       value: "4.17"
+    - name: CHANNEL_STREAM
+      value: "fast"
     - name: ARTIFACTS_BUILD_ROOT
       value: quay-proxy.ci.openshift.org/openshift/ci:ocp_builder_rhel-9-golang-1.23-openshift-4.19
     - name: DOCKERFILE_ADDITIONS

--- a/examples/pipeline.yaml
+++ b/examples/pipeline.yaml
@@ -31,6 +31,8 @@ spec:
       value: "gcp"
     - name: OPENSHIFT_VERSION
       value: "4.17"
+    - name: CHANNEL_STREAM
+      value: "4-stable"
     - name: ARTIFACTS_BUILD_ROOT
       value: quay-proxy.ci.openshift.org/openshift/ci:ocp_builder_rhel-9-golang-1.23-openshift-4.19
     - name: DOCKERFILE_ADDITIONS

--- a/tasks/run-prowjob.yaml
+++ b/tasks/run-prowjob.yaml
@@ -11,7 +11,7 @@ spec:
   - name: GANGWAY_TOKEN
     type: string
     default: gangway-token
-    description: Token to authenticate with gangway
+    description: 'Token to authenticate with gangway'
 
   # Test parameters
   - name: CLOUD_PROVIDER
@@ -21,11 +21,16 @@ spec:
   - name: OPENSHIFT_VERSION
     type: string
     default: '4.18'
-    description: 'OpenShift version to test against'
+    description: 'OpenShift version to test against; must be in the format 4.x; if you are using a stable, fast or candidate channel, you can specify 4.x.y'
+  - name: CHANNEL_STREAM
+    type: string
+    default: 'stable'
+    description: 'OpenShift stream/channel to test against; one of stable, fast, candidate, 4-stable, nightly, konflux-nightly, ci;
+     stable, fast and candidate are channels from the Cincinnati server, the other ones are streams from the release controller; always the latest version of the stream/channel will be used'
   - name: ARCHITECTURE
     type: string
     default: 'amd64'
-    description: 'Architecture to test against. amd64, arm64'
+    description: 'Architecture to test against; one of amd64, arm64'
 
   # Artifacts image parameters
   - name: ARTIFACTS_BUILD_ROOT
@@ -50,7 +55,7 @@ spec:
   - name: PULL_SECRET
     type: string
     default: ''
-    description: 'Secret created by the user in https://vault.ci.openshift.org/ in the test-credential namespace with the field .dockerconfigjson. Necessary for private images'
+    description: 'Secret created by the user in https://vault.ci.openshift.org/ in the test-credential namespace with the field .dockerconfigjson; necessary for private images'
   - name: ENVS
     type: string
     default: ''
@@ -77,6 +82,8 @@ spec:
       value: $(params.DEPLOY_TEST_COMMAND)
     - name: OPENSHIFT_VERSION
       value: $(params.OPENSHIFT_VERSION)
+    - name: CHANNEL_STREAM
+      value: $(params.CHANNEL_STREAM)
     - name: ARCHITECTURE
       value: $(params.ARCHITECTURE)
     - name: SNAPSHOT
@@ -142,8 +149,9 @@ spec:
       yq -i 'del(.build_root.project_image)' config.yaml
       yq -i 'del(.tests[].steps.test[].cli)' config.yaml
       yq -i '(.build_root.project_image += {"dockerfile_literal": strenv(DOCKERFILE_LITERAL) })' config.yaml
+
+      # Konflux Image
       KONFLUX_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.components[] | select(.name == $component_name) | .containerImage' <<< "${SNAPSHOT}")
-      # KONFLUX_IMAGE=$(jq -r -c '.components[0].containerImage' <<< "${SNAPSHOT}")
       TAG=$(echo "$KONFLUX_IMAGE" | cut -d':' -f2)
       RNN=$(echo "$KONFLUX_IMAGE" | cut -d':' -f1)
       NAME=$(echo "$RNN" | rev | cut -d'/' -f1 | rev)
@@ -156,18 +164,41 @@ spec:
       if [[ -n "$PULL_SECRET" ]]; then
         yq -i '(.external_images.konflux.pull_secret = "'${PULL_SECRET}'")' config.yaml
       fi
-      yq -i '(.releases.latest.release.version = "'${OPENSHIFT_VERSION}'")' config.yaml
-      yq -i '(.releases.latest.release.architecture = "amd64")' config.yaml
-      yq -i '(.releases.latest.release.channel = "stable")' config.yaml
 
+      # Release
+      if [[ $CHANNEL_STREAM == "stable" || $CHANNEL_STREAM == "fast" || $CHANNEL_STREAM == "candidate" ]]; then
+        yq -i '(.releases.latest.release.channel = "'${CHANNEL_STREAM}'")' config.yaml
+        yq -i '(.releases.latest.release.version = "'${OPENSHIFT_VERSION}'")' config.yaml
+        yq -i '(.releases.latest.release.architecture = "amd64")' config.yaml
+      elif [[ $CHANNEL_STREAM == "4-stable" ]]; then
+        minor=$(echo "$OPENSHIFT_VERSION" | cut -d. -f2)
+        minor_plus_one=$((minor + 1))
+        yq -i '(.releases.latest.prerelease.product = "ocp" )' config.yaml
+        yq -i '(.releases.latest.prerelease.architecture = "amd64")' config.yaml
+        yq -i '(.releases.latest.prerelease.version_bounds.lower = "4.'${minor}'.0-0")' config.yaml
+        yq -i '(.releases.latest.prerelease.version_bounds.upper = "4.'${minor_plus_one}'.0-0")' config.yaml
+        yq -i '(.releases.latest.prerelease.version_bounds.stream = "'${CHANNEL_STREAM}'")' config.yaml
+        yq -i 'del( .releases.latest.release)' config.yaml
+      elif [[ $CHANNEL_STREAM == "nightly" || $CHANNEL_STREAM == "konflux-nightly" || $CHANNEL_STREAM == "ci" ]]; then
+        yq -i '(.releases.latest.candidate.product = "ocp" )' config.yaml
+        yq -i '(.releases.latest.candidate.architecture = "amd64")' config.yaml
+        yq -i '(.releases.latest.candidate.stream = "'${CHANNEL_STREAM}'")' config.yaml
+        yq -i '(.releases.latest.candidate.version = "'${OPENSHIFT_VERSION}'")' config.yaml
+        yq -i 'del( .releases.latest.release)' config.yaml
+      else
+        echo "❌ Error: Invalid channel/stream specified. Use one of stable, fast, candidate, 4-stable, nightly, konflux-nightly, ci."
+        exit 1
+      fi
+
+      # Placeholders modifications
       sed -i "s|operator-placeholder|pipeline:konflux|g" config.yaml
       sed -i "s|operator-placeholder|pipeline:konflux|g" config.yaml
       sed -i "s|command-placeholder|$DEPLOY_TEST_COMMAND|g" config.yaml
 
       # Arch specific modifications
       if [[ $ARCHITECTURE == "arm64" ]]; then
+        yq -i '(.releases.latest.*.architecture = "multi")' config.yaml
         sed -i "s|amd64|arm64|g" config.yaml
-        yq -i '(.releases.latest.release.architecture = "multi")' config.yaml
       fi
 
       # ENV var modifications


### PR DESCRIPTION
This PR adds the CHANNEL_STREAM parameter, which accepts these values:
 - stable, fast, candidate: This will request a release from the Cincinnati server
 - 4-stable: This will request a prerelease from release-controller
 - ci, nightly, konflux-nightly: This will request one of the specified candidate stream from the release-controller

This PR also adds better documentation of the pipeline parameters.