### PR TITLE
Add MAX_RETRIES and RETRY_DELAY parameters

### DIFF
--- a/tasks/provide-prowjob/0.1/README.md
+++ b/tasks/provide-prowjob/0.1/README.md
@@ -37,8 +37,8 @@ The pipeline consists of the following tasks:
 | INCLUDE_IMAGES | Bool flag whether to include the `images` stanza in the ci-operator config | 0 | false |
 | INCLUDE_OPERATOR | Bool flag whether to include the `operator` stanza in the ci-operator config | 0 | false |
 | ENVS | Comma-separated list of additional environment variables to pass to the prowjob, e.g. TEST_ENV=example,ANOTHER_ENV=example2 |  | false |
-| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 3 | false |
-| RETRY_DELAY | Time in seconds to wait between retry attempts | 20 | false |
+| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 5 | false |
+| RETRY_DELAY | Time in seconds to wait between retry attempts | 60 | false |
 
 ## ⚙️ How It Works
 Patch ci-operator Config:

--- a/tasks/provide-prowjob/0.1/README.md
+++ b/tasks/provide-prowjob/0.1/README.md
@@ -37,6 +37,8 @@ The pipeline consists of the following tasks:
 | INCLUDE_IMAGES | Bool flag whether to include the `images` stanza in the ci-operator config | 0 | false |
 | INCLUDE_OPERATOR | Bool flag whether to include the `operator` stanza in the ci-operator config | 0 | false |
 | ENVS | Comma-separated list of additional environment variables to pass to the prowjob, e.g. TEST_ENV=example,ANOTHER_ENV=example2 |  | false |
+| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 3 | false |
+| RETRY_DELAY | Time in seconds to wait between retry attempts | 20 | false |
 
 ## ⚙️ How It Works
 Patch ci-operator Config:

--- a/tasks/provide-prowjob/0.1/provide-prowjob.yaml
+++ b/tasks/provide-prowjob/0.1/provide-prowjob.yaml
@@ -43,6 +43,14 @@ spec:
     type: string
     default: ''
     description: 'Optional environment variables to inject into the test; separated by commas; e.g. VAR1=val1,VAR2=val2'
+  - name: MAX_RETRIES
+    description: 'Maximum number of retries to trigger the prowjob'
+    type: string
+    default: "3"
+  - name: RETRY_DELAY
+    description: 'Time in seconds to wait between retry attempts'
+    type: string
+    default: "20"
   results:
   - name: PROWJOB_ID
     description: The triggered prowjob id
@@ -97,6 +105,10 @@ spec:
       value: $(params.INCLUDE_OPERATOR)
     - name: ENVS
       value: $(params.ENVS)
+    - name: MAX_RETRIES
+      value: $(params.MAX_RETRIES)
+    - name: RETRY_DELAY
+      value: $(params.RETRY_DELAY)
     script: |
       #!/usr/bin/env bash
 
@@ -196,7 +208,6 @@ spec:
           }')
 
       # Triggering PJ via gangway and getting ID/URL
-      MAX_RETRIES=3
       RETRY_COUNT=0
       while true; do
         curl -s -X POST -H "Authorization: Bearer $GANGWAY_TOKEN" \
@@ -212,8 +223,8 @@ spec:
           echo "👉 Probably expired gangway token or Gangway service is down."
           exit 1
         fi
-        echo "Retry $RETRY_COUNT/$MAX_RETRIES: Failed to trigger prowjob, retrying in 10 seconds..."
-        sleep 20
+        echo "Retry $RETRY_COUNT/$MAX_RETRIES: Failed to trigger prowjob, retrying in $RETRY_DELAY seconds..."
+        sleep "$RETRY_DELAY"
       done
 
       # Getting the prowjob spyglass URL

--- a/tasks/provide-prowjob/0.1/provide-prowjob.yaml
+++ b/tasks/provide-prowjob/0.1/provide-prowjob.yaml
@@ -46,11 +46,11 @@ spec:
   - name: MAX_RETRIES
     description: 'Maximum number of retries to trigger the prowjob'
     type: string
-    default: "3"
+    default: "5"
   - name: RETRY_DELAY
     description: 'Time in seconds to wait between retry attempts'
     type: string
-    default: "20"
+    default: "60"
   results:
   - name: PROWJOB_ID
     description: The triggered prowjob id

--- a/tasks/run-prowjob/0.1/README.md
+++ b/tasks/run-prowjob/0.1/README.md
@@ -42,8 +42,8 @@ The pipeline consists of the following tasks:
 | BUNDLE_NS | Namespace to use if installing bundle image |  | false |
 | PULL_SECRET | Secret created by the user in https://vault.ci.openshift.org/ in the test-credential namespace with the field .dockerconfigjson; necessary for private images |  | false |
 | ENVS | Optional environment variables to inject into the test; separated by commas; e.g. VAR1=val1,VAR2=val2 |  | false |
-| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 3 | false |
-| RETRY_DELAY | Time in seconds to wait between retry attempts | 20 | false |
+| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 5 | false |
+| RETRY_DELAY | Time in seconds to wait between retry attempts | 60 | false |
 
 
 

--- a/tasks/run-prowjob/0.1/README.md
+++ b/tasks/run-prowjob/0.1/README.md
@@ -42,6 +42,8 @@ The pipeline consists of the following tasks:
 | BUNDLE_NS | Namespace to use if installing bundle image |  | false |
 | PULL_SECRET | Secret created by the user in https://vault.ci.openshift.org/ in the test-credential namespace with the field .dockerconfigjson; necessary for private images |  | false |
 | ENVS | Optional environment variables to inject into the test; separated by commas; e.g. VAR1=val1,VAR2=val2 |  | false |
+| MAX_RETRIES | Maximum number of retries to trigger the prowjob | 3 | false |
+| RETRY_DELAY | Time in seconds to wait between retry attempts | 20 | false |
 
 
 

--- a/tasks/run-prowjob/0.1/run-prowjob.yaml
+++ b/tasks/run-prowjob/0.1/run-prowjob.yaml
@@ -64,6 +64,14 @@ spec:
     type: string
     default: ''
     description: 'Optional environment variables to inject into the test; separated by commas; e.g. VAR1=val1,VAR2=val2'
+  - name: MAX_RETRIES
+    description: 'Maximum number of retries to trigger the prowjob'
+    type: string
+    default: "3"
+  - name: RETRY_DELAY
+    description: 'Time in seconds to wait between retry attempts'
+    type: string
+    default: "20"
   results:
   - name: PROWJOB_ID
     description: The triggered prowjob id
@@ -122,6 +130,10 @@ spec:
       value: $(params.PULL_SECRET)
     - name: ENVS
       value: $(params.ENVS)
+    - name: MAX_RETRIES
+      value: $(params.MAX_RETRIES)
+    - name: RETRY_DELAY
+      value: $(params.RETRY_DELAY)
     script: |
       #!/usr/bin/env bash
 
@@ -289,7 +301,6 @@ spec:
         }')
 
       # Triggering PJ via gangway and getting ID/URL
-      MAX_RETRIES=3
       RETRY_COUNT=0
       while true; do
         curl -s -X POST -H "Authorization: Bearer $GANGWAY_TOKEN" \
@@ -305,8 +316,8 @@ spec:
           echo "👉 Probably expired gangway token or Gangway service is down."
           exit 1
         fi
-        echo "Retry $RETRY_COUNT/$MAX_RETRIES: Failed to trigger prowjob, retrying in 10 seconds..."
-        sleep 20
+        echo "Retry $RETRY_COUNT/$MAX_RETRIES: Failed to trigger prowjob, retrying in $RETRY_DELAY seconds..."
+        sleep "$RETRY_DELAY"
       done
 
       # Getting the prowjob spyglass URL

--- a/tasks/run-prowjob/0.1/run-prowjob.yaml
+++ b/tasks/run-prowjob/0.1/run-prowjob.yaml
@@ -67,11 +67,11 @@ spec:
   - name: MAX_RETRIES
     description: 'Maximum number of retries to trigger the prowjob'
     type: string
-    default: "3"
+    default: "5"
   - name: RETRY_DELAY
     description: 'Time in seconds to wait between retry attempts'
     type: string
-    default: "20"
+    default: "60"
   results:
   - name: PROWJOB_ID
     description: The triggered prowjob id


### PR DESCRIPTION
The task is going to retry triggering the job a couple of times but the number of max retries and delay time are hard-coded. In some scenarios user may want to change the default values (e.g. adding a longer delay) so this made MAX_RETRIES and RETRY_DELAY parameters that user can pass to the task.