### PR TITLE
provide-prowjob: filter-out unused tests

### DIFF
--- a/tasks/provide-prowjob/0.1/provide-prowjob.yaml
+++ b/tasks/provide-prowjob/0.1/provide-prowjob.yaml
@@ -169,6 +169,17 @@ spec:
         yq -i '(.external_images."'${IMAGE_IN_CONFIG}'".tag = "'${TAG}'")' config.yaml
       fi
 
+      # Filter tests to only include the test matching this prowjob
+      if [[ -z "$VARIANT" ]]; then
+        PJ_PREFIX="-ci-${ORG}-${REPO}-${TARGET_BRANCH}-"
+      else
+        PJ_PREFIX="-ci-${ORG}-${REPO}-${TARGET_BRANCH}__${VARIANT}-"
+      fi
+      TEST_NAME="${PROWJOB_NAME#*${PJ_PREFIX}}"
+      if [[ -n "$TEST_NAME" && "$TEST_NAME" != "$PROWJOB_NAME" ]]; then
+        yq -i 'del(.tests[] | select(.as != "'"${TEST_NAME}"'"))' config.yaml
+      fi
+
       # ENV var modifications
       if [[ -n "$ENVS" ]]; then
         IFS=',' read -ra PAIRS <<< "$ENVS"


### PR DESCRIPTION
Extracts the test name by stripping everything up to and including the prefix from PROWJOB_NAME using bash parameter expansion (${PROWJOB_NAME#*${PJ_PREFIX}}). For example:
    - periodic-ci-openshift-myrepo-main-e2e-aws → e2e-aws
    - periodic-ci-openshift-myrepo-main__ocp416-e2e-gcp → e2e-gcp