### PR TITLE
Add support for Prow CI jobs hosted in different repositories

### DIFF
--- a/tasks/provide-prowjob/0.1/provide-prowjob.yaml
+++ b/tasks/provide-prowjob/0.1/provide-prowjob.yaml
@@ -14,6 +14,12 @@ spec:
   - name: PROWJOB_NAME
     type: string
     description: 'Name of the Prow job to trigger'
+  - name: PROWJOB_ORG
+    type: string
+    description: 'Name of the GitHub organization hosting the Prow job to trigger'
+  - name: PROWJOB_REPO
+    type: string
+    description: 'Name of the GitHub repository hosting the Prow job to trigger'
   - name: IMAGE_IN_CONFIG
     type: string
     default: ''
@@ -95,6 +101,10 @@ spec:
       value: $(params.DOCKERFILE_ADDITIONS)
     - name: PROWJOB_NAME
       value: $(params.PROWJOB_NAME)
+    - name: PROWJOB_ORG
+      value: $(params.PROWJOB_ORG)
+    - name: PROWJOB_REPO
+      value: $(params.PROWJOB_REPO)
     - name: IMAGE_IN_CONFIG
       value: $(params.IMAGE_IN_CONFIG)
     - name: VARIANT
@@ -138,6 +148,11 @@ spec:
         DOCKERFILE_LITERAL=""
       fi
       export DOCKERFILE_LITERAL
+
+      if [[ -n "$PROWJOB_ORG" ]] && [[ -n "$PROWJOB_REPO" ]]; then
+        ORG="${PROWJOB_ORG}"
+        REPO="${PROWJOB_REPO}"
+      fi
 
       if [[ -z "$VARIANT" ]]; then
         CI_OPERATOR_CONFIG_URL="https://raw.githubusercontent.com/openshift/release/master/ci-operator/config/${ORG}/${REPO}/${ORG}-${REPO}-${TARGET_BRANCH}.yaml"


### PR DESCRIPTION
Fix `could not build execution graph: the following names were not found in the config or were duplicates` by adding support for triggering Prow CI jobs hosted in github organizations and repositories different from org/repo where the konflux pipeline is hosted.

Currently, $ORG and $REPO are retrieved using konflux labels `pac.test.appstudio.openshift.io/url-org` and `pac.test.appstudio.openshift.io/url-repository` thus `CI_OPERATOR_CONFIG_URL` will only contain Prow CI jobs defined within the same repository as the tekton pipeline

Example:

Be able to trigger Prow CI jobs hosted in [the openshift-eng/agent-qe-infra](https://github.com/openshift/release/tree/main/ci-operator/jobs/openshift-eng/agent-qe-infra) while having konflux tekton files hosted in https://github.com/openshift/agent-installer-utils/tree/main/.tekton 