### PR TITLE
KFLUXVNGD-900: Fix ephemeral cluster tasks for HyperShift workflow

### DIFF
--- a/examples/ephemeral-cluster/pipeline-hypershift.yaml
+++ b/examples/ephemeral-cluster/pipeline-hypershift.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: ephemeral-cluster-hypershift
+spec:
+  description: >-
+    Provision and deprovision an ephemeral HyperShift hosted cluster.
+  tasks:
+  - name: provision-ephemeral-cluster
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/openshift/konflux-tasks
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
+    params:
+    - name: ownerName
+      value: $(context.pipelineRun.name)
+    - name: ownerUid
+      value: $(context.pipelineRun.uid)
+    - name: workflow
+      value: hypershift-hostedcluster-workflow
+    - name: clusterProfile
+      value: openshift-org-aws
+    - name: env
+      value: '{"COMPUTE_NODE_TYPE": "m5.xlarge", "HYPERSHIFT_NODE_COUNT": "3"}'
+    - name: releases
+      value: '{"latest":{"release":{"channel":"stable","version":"4.17","architecture":"multi"}}}'
+  - name: run-test
+    runAfter:
+    - provision-ephemeral-cluster
+    params:
+    - name: kubeconfigSecretRef
+      value: $(tasks.provision-ephemeral-cluster.results.secretRef)
+    taskSpec:
+      params:
+      - name: kubeconfigSecretRef
+        type: string
+        description: "The secret that holds the Ephemeral Cluster kubeconfig"
+      steps:
+      - name: run-test
+        image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:aa2c97da9bb73a4e8d1c6b41950f8d902b74461be0e042debe89277fdc4ebe49
+        env:
+        - name: KUBECONFIG
+          value: /var/run/secrets/cluster/kubeconfig
+        volumeMounts:
+        - name: cluster-credentials
+          mountPath: /var/run/secrets/cluster
+          readOnly: true
+        script: |
+          #!/usr/bin/env bash
+          set -eo pipefail
+
+          oc whoami
+      volumes:
+      - name: cluster-credentials
+        secret:
+          secretName: $(params.kubeconfigSecretRef)
+
+  finally:
+  - name: deprovision-ephemeral-cluster
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/openshift/konflux-tasks
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+    params:
+    - name: testPlatformClusterClaimName
+      value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+    - name: testPlatformClusterClaimNamespace
+      value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)
+

--- a/tasks/copy-secrets-to-ephemeral-cluster/0.1/README.md
+++ b/tasks/copy-secrets-to-ephemeral-cluster/0.1/README.md
@@ -1,0 +1,10 @@
+# copy-secrets-to-ephemeral-cluster task
+
+The copy-secrets-to-ephemeral-cluster task copies Secrets from the current namespace into a configurable namespace on an ephemeral cluster. The name and content of each Secret is unaltered in the process.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|clusterCredentialsSecretRef|Name of the Secret containing kubeconfig and password to access the provisioned ephemeral cluster. This value comes from the results of the `provision-ephemeral-cluster` task||true|
+|namespace|The destination namespace for the secrets. The namespace must already exist.||true|
+|labelSelector|A label selector identifying the secrets to be copied||true|

--- a/tasks/copy-secrets-to-ephemeral-cluster/0.1/copy-secrets-to-ephemeral-cluster.yaml
+++ b/tasks/copy-secrets-to-ephemeral-cluster/0.1/copy-secrets-to-ephemeral-cluster.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: copy-secrets-to-ephemeral-cluster
+spec:
+  description: >-
+    This Task copies Secrets from the current namespace into a configurable namespace on an
+    ephemeral cluster. The name and content of each Secret is unaltered in the process.
+  params:
+  - name: clusterCredentialsSecretRef
+    type: string
+    description: >-
+      Name of the Secret containing kubeconfig and password to access the provisioned ephemeral cluster
+  - name: namespace
+    type: string
+    description: The destination namespace for the secrets. The namespace must already exist.
+  - name: labelSelector
+    type: string
+    description: A label selector identifying the secrets to be copied
+  steps:
+  - name: copy-secrets
+    image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:aa2c97da9bb73a4e8d1c6b41950f8d902b74461be0e042debe89277fdc4ebe49
+    env:
+    - name: KUBECONFIG_VALUE
+      valueFrom:
+        secretKeyRef:
+          name: $(params.clusterCredentialsSecretRef)
+          key: kubeconfig
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: LABEL_SELECTOR
+      value: $(params.labelSelector)
+    script: |
+      #!/bin/bash
+      set -eo pipefail
+
+      DEST_KUBECONFIG="$(mktemp /tmp/kubeconfig.XXXXX)"
+      echo "$KUBECONFIG_VALUE" >"$DEST_KUBECONFIG"
+
+      oc get secrets -l "$LABEL_SELECTOR" -o json \
+        | jq --arg ns "$NAMESPACE" '.items[].metadata.namespace=$ns' \
+        | jq 'del(.items[] | .metadata.creationTimestamp,
+                  .metadata.uid, .metadata.resourceVersion,
+                  .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")' \
+        | oc apply --kubeconfig="$DEST_KUBECONFIG" -f -

--- a/tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+++ b/tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
@@ -20,7 +20,7 @@ spec:
     description: "Wait for the ephemeral cluster to be deprovisioned until this timeout is reached"
   steps:
   - name: deprovision-ephemeral-cluster
-    image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+    image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:aa2c97da9bb73a4e8d1c6b41950f8d902b74461be0e042debe89277fdc4ebe49
     env:
     - name: CLAIM_NAME
       value: $(params.testPlatformClusterClaimName)
@@ -32,6 +32,18 @@ spec:
       #!/bin/bash
       set -eo pipefail
 
+      DEPROVISION_SUCCESS=0
+
+      on_exit() {
+          if [ "$DEPROVISION_SUCCESS" -eq 0 ]; then
+              echo "Dumping TestPlatformCluster claim status for debugging:"
+              oc -n "$NAMESPACE" get testplatformclusters.ci.openshift.org "$CLAIM_NAME" -o yaml
+          fi
+      }
+      trap on_exit EXIT
+
+      echo "Deprovisioning cluster: $CLAIM_NAME (namespace: $NAMESPACE)"
+
       cat >deprovision-patch.json <<EOF
       [{
           "op": "add",
@@ -40,9 +52,12 @@ spec:
       }]
       EOF
 
+      echo "Patching TestPlatformCluster claim to trigger teardown..."
       oc -n "$NAMESPACE" patch testplatformclusters.ci.openshift.org "$CLAIM_NAME" --type=json --patch-file=deprovision-patch.json
 
+      echo "Waiting for deprovisioning to complete (timeout: $CLUSTER_DEPROVISIONING_TIMEOUT)..."
       if oc -n "$NAMESPACE" wait testplatformclusters.ci.openshift.org "$CLAIM_NAME" --for=condition=ProwJobCompleted=true --timeout="$CLUSTER_DEPROVISIONING_TIMEOUT"; then
+        DEPROVISION_SUCCESS=1
         echo 'The cluster has been properly deprovisioned'
       else
         echo "Error: failed to deprovision the cluster"

--- a/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
+++ b/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
@@ -156,7 +156,7 @@ spec:
     type: string
   steps:
   - name: provision-ephemeral-cluster
-    image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+    image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:aa2c97da9bb73a4e8d1c6b41950f8d902b74461be0e042debe89277fdc4ebe49
     env:
       - name: BUILD_ROOT
         value: $(params.buildRoot)
@@ -197,6 +197,15 @@ spec:
       # Use this to make sure the PJ URL is printed only once
       URL_DUMPED=0
       TP_CLUSTER_NAME=''
+      CLUSTER_READY=0
+
+      on_exit() {
+          if [ "$CLUSTER_READY" -eq 0 ] && [ -n "$TP_CLUSTER_NAME" ]; then
+              echo "Dumping TestPlatformCluster claim status for debugging:"
+              oc get testplatformclusters.ci.openshift.org "$TP_CLUSTER_NAME" -o yaml
+          fi
+      }
+      trap on_exit EXIT
 
       check_cluster_ready() {
           ec="$1"
@@ -208,6 +217,7 @@ spec:
           fi
 
           phase=$(jq -r '(.status.conditions // [])[]|select(.type == "_EphemeralClusterPhase").message' <<<"$ec")
+          echo "Cluster phase: ${phase:-unknown}"
           if [ "$phase" = "Failed" ]; then
               echo "Error: failed to provision the cluster"
               exit 1
@@ -216,6 +226,7 @@ spec:
           claim_ready=$(jq -r 'any((.status.conditions // [])[]; .type == "Ready" and .status == "True")' <<<"$ec")
           cluster_ready=$(jq -r 'any((.status.conditions // [])[]; .type == "ClusterReady" and .status == "True")' <<<"$ec")
           if [ "$claim_ready" = "true" ] && [ "$cluster_ready" = "true" ]; then
+              CLUSTER_READY=1
               echo "The cluster is ready"
               echo "SecretRef: $SECRET"
               echo -n "$SECRET" >"$(results.secretRef.path)"
@@ -271,18 +282,34 @@ spec:
           baseImages: $BASE_IMAGES
           externalImages: $EXTERNAL_IMAGES
           releases: $RELEASES
-          resources: $RESOURCES
           test:
-            clusterProfile: $CLUSTER_PROFILE
-            clusterClaim: $CLUSTER_CLAIM
             env: $ENV
             workflow: $WORKFLOW
         writeConnectionSecretToRef:
           name: $SECRET
       EOF
 
+      # Add optional fields only when provided
+      if [ -n "$RESOURCES" ]; then
+        yq -i '.spec.ciOperator.resources = env(RESOURCES)' testplatformcluster_claim.yaml
+      fi
+      if [ -n "$CLUSTER_PROFILE" ]; then
+        yq -i '.spec.ciOperator.test.clusterProfile = strenv(CLUSTER_PROFILE)' testplatformcluster_claim.yaml
+      fi
+      if [ "$CLUSTER_CLAIM" != '{}' ]; then
+        yq -i '.spec.ciOperator.test.clusterClaim = env(CLUSTER_CLAIM)' testplatformcluster_claim.yaml
+      fi
+
+      echo "Generated TestPlatformCluster claim:"
+      cat testplatformcluster_claim.yaml
+
+      echo "Creating TestPlatformCluster claim..."
       TP_CLUSTER_NAME=$(oc create -f testplatformcluster_claim.yaml -o=jsonpath='{.metadata.name}')
+      echo "Created TestPlatformCluster: $TP_CLUSTER_NAME"
 
       start_timeout &
+      echo "Watching for cluster to become ready (timeout: $CLUSTER_READY_TIMEOUT)..."
       watch_ephemeral_cluster
+      echo "Watch ended without detecting cluster ready or failed state"
+      exit 1
 


### PR DESCRIPTION
**Summary**

- Fix provision-ephemeral-cluster to conditionally include clusterClaim, clusterProfile, and resources fields only when provided — empty defaults previously triggered API validation errors for workflows like hypershift-hostedcluster-workflow. Also fix a silent exit-0 bug where the watch could end without detecting a ready or failed state                                       
- Add debugging output to both provision and deprovision tasks (dump TestPlatformCluster claim status on failure, log cluster phase transitions)
- Bump konflux-test image to v1.4.52 in both tasks                                                                                                                                                                                                                                                                                                                                        
- Add copy-secrets-to-ephemeral-cluster task, adapted from the EaaS eaas-copy-secrets-to-ephemeral-cluster StepAction in konflux-ci/build-definitions to work with the secret-based kubeconfig pattern
- Add an example pipeline demonstrating end-to-end ephemeral HyperShift cluster provisioning, testing, and deprovisioning