### PR TITLE
Fix provision-ephemeral-cluster claim readiness detection and secret naming

### DIFF
--- a/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
+++ b/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
@@ -187,7 +187,7 @@ spec:
       - name: OWNER_UID
         value: $(params.ownerUid)
       - name: SECRET
-        value: $(context.taskRun.name)-secret
+        value: $(context.taskRun.name)
       - name: CLUSTER_READY_TIMEOUT
         value: $(params.timeout)
     script: |
@@ -213,8 +213,9 @@ spec:
               exit 1
           fi
 
+          claim_ready=$(jq -r 'any((.status.conditions // [])[]; .type == "Ready" and .status == "True")' <<<"$ec")
           cluster_ready=$(jq -r 'any((.status.conditions // [])[]; .type == "ClusterReady" and .status == "True")' <<<"$ec")
-          if [ "$cluster_ready" = "true" ]; then
+          if [ "$claim_ready" = "true" ] && [ "$cluster_ready" = "true" ]; then
               echo "The cluster is ready"
               echo "SecretRef: $SECRET"
               echo -n "$SECRET" >"$(results.secretRef.path)"


### PR DESCRIPTION
The task was only checking for the "ClusterReady" condition which doesn't account for secret propagation. The readiness check now waits for both "Ready" and "ClusterReady" conditions to ensure the claim is fully ready including the connection secret.

The secret name was derived from the TaskRun name with a "-secret" suffix, which could exceed the 63-character Kubernetes resource name limit for long TaskRun names, preventing the controller from creating the secret.

Assisted-by: Claude claude-opus-4-6